### PR TITLE
Deriving the project name from `src/<project name>`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,3 +6,8 @@ Changelog
 ------------------
 
 * First release on PyPI.
+
+0.1.28 (2020-05-17)
+------------------
+
+* Deriving the project name from `src/<project name>` vs. the top-level directory name.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,10 @@
+# Guides
+
+The guides below provide a step-by-step walkthrough of common tasks inside whisk projects.
+
+```eval_rst
+.. toctree::
+   :maxdepth: 2
+
+   rename_project
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ The [whisk-ml](https://github.com/whisk-ml) GitHub org contains example whisk pr
    dvc
    heroku
    packaging
+   guides
    modules
    changelog
    contributing

--- a/docs/rename_project.md
+++ b/docs/rename_project.md
@@ -1,0 +1,44 @@
+# Renaming a project
+
+Follow the following steps if you wish to change the name of a whisk project.
+
+## 1. Update setup.py
+
+In the project's `setup.py` file, update the `setup` function's `name` argument and the cli command:
+
+```diff
+-    name='<old project name>',
++    name='<new project name>',
+      entry_points={
+        'console_scripts': [
+-            '<old project name>=<old project name>.cli.main:cli',
++            '<new project name>=<new project name>.cli.main:cli',
+        ],
+    },
+```
+
+## 2. Update the src/<project name> directory
+
+Rename the `src/<project name>` directory:
+
+    mv src/<old project name> src/<new project name>
+
+## 3. Find and replace the project name in project files
+
+In your project files, find and replace `<old project name>.` with `<new project name>.`
+
+## 4. Re-install the package
+
+Type the following to re-install the package in editable mode:
+
+    pip install -e .
+
+## 5. Run tests
+
+Run both `pytest` and `tox` to ensure all tests pass with the new project name.
+
+## Extra considerations
+
+### DVC
+
+If your project is using [DVC](dvc.html), you may need to run [`dvc move`](https://dvc.org/doc/command-reference/move) to update the paths of files tracked with DVC.

--- a/whisk/project.py
+++ b/whisk/project.py
@@ -26,8 +26,8 @@ class Project:
         """The top-level project directory (str)"""
         self.path = Path(self.dir)
         """The top-level project directory as a pathlib.Path"""
-        self.name = self.path.stem
-        """Name of the project derived from the top-level directory (str)"""
+        self.name = self.name_from_src_dir(self.path / "src")
+        """Name of the project derived from the src/<project_name> directory (str)"""
         self.module_dir = module_dir
         """
         Location of the project's module directory as a pathlib.Path.
@@ -53,6 +53,22 @@ class Project:
             Location of the project's whisk commands directory as a pathlib.Path.
             Returns `None` if not within a whisk project.
             """
+
+    def name_from_src_dir(self, src_dir):
+        """
+        Derives the project name from the first child directory in the ``src/``
+        directory that contains an ``__init__.py`` file.
+
+        Parameters
+        ----------
+        src_dir : pathlib.Path
+            Path object referencing the project ``src/`` directory.
+        """
+
+        src_children = sorted(src_dir.glob("*/__init__.py"))
+        if len(src_children) == 0:
+            return None
+        return src_children[0].parent.stem
 
     def validate_in_project(self):
         """

--- a/whisk/whisk.py
+++ b/whisk/whisk.py
@@ -17,6 +17,15 @@ def root_module_dir():
 def cookiecutter_template_dir():
     return str(root_module_dir() / 'template/')
 
+def project_name_to_slug(project_name):
+    """
+    Converts a raw project name to a slug:
+
+    * Makes all letters lowercase
+    * Replaces spaces with underscores
+    """
+    return project_name.lower().replace(' ', '_')
+
 def create(project_name, output_dir=".", setup=None, force=False):
     """
     Creates a whisk project.
@@ -24,7 +33,7 @@ def create(project_name, output_dir=".", setup=None, force=False):
     Parameters
     ----------
     project_name : str
-        Name of the directory to create for the project.
+        Name of the directory to create for the project. This is converted to a slug via :func:`project_name_to_slug`.
 
     output_dir : str, optional
         Path to create the directory. Default is the current working directory.
@@ -38,10 +47,13 @@ def create(project_name, output_dir=".", setup=None, force=False):
     # Locks to a specific version as earlier and later versions of whisk could expect a different
     # template structure.
     whisk_version = "whisk=={}".format(whisk.__version__)
+
+    project_name_slug = project_name_to_slug(project_name)
+
     # `whisk_dependency` is more flexible (for example, specifying a local install)
     # than `whisk_install_requires` and is used in testing to require the local version of whisk.
     extra_content = {
-        "project_name": project_name,
+        "project_name": project_name_slug,
         # Added to the project's requirements.txt
         "whisk_dependency": whisk_version,
         # Added to the project's setup.py file


### PR DESCRIPTION
Previously the project name was derived from the top-level directory name. Now it is derived directly from the module name used within the `src` directory. This makes the top-level directory name more flexible.

Within a project, the project name is currently used for naming the default S3 bucket.

This also adds a step-by-step guide for renaming a project to the docs.